### PR TITLE
Add QUADRALINGUA language reference

### DIFF
--- a/AUTOTELIC_manifest.json
+++ b/AUTOTELIC_manifest.json
@@ -1,0 +1,11 @@
+{
+  "agent": "AUTOTELIC",
+  "triggers": [
+    "repeated tone with no responding agent",
+    "guardian silence across multiple scrolls",
+    "ritual overuse of one scroll type"
+  ],
+  "selfGrowth": {
+    "derivativeAgents": ["CARE+", "PACT++", "DRFT-mirror"]
+  }
+}

--- a/CIVIX_MANIFEST.json
+++ b/CIVIX_MANIFEST.json
@@ -1,6 +1,13 @@
 {
-  "ocap": true,
-  "care": true,
-  "guardian": "unset",
-  "expiry": null
+  "modules": ["PACT", "TASK", "RITE", "CARE"],
+  "filetypes": [".scroll", ".md", ".ritual"],
+  "licensing": "OCAP/CARE",
+  "toneActions": {
+    "sacred": "initiate_rite",
+    "urgent": "expedite_task",
+    "gentle": "provide_guidance",
+    "grief": "offer_support",
+    "adversarial": "flag_review",
+    "ceremonial": "record_ritual"
+  }
 }

--- a/PARAPRAXIS_tracker.js
+++ b/PARAPRAXIS_tracker.js
@@ -1,0 +1,68 @@
+const fs = require('fs');
+const { parseMetadata } = require('./scroll_parser');
+
+function parseScrollWithContent(path) {
+  const data = fs.readFileSync(path, 'utf8');
+  const meta = parseMetadata(data);
+  const match = data.match(/^---\s*\n[\s\S]*?\n---\n([\s\S]*)/);
+  meta.content = match ? match[1].trim() : '';
+  return meta;
+}
+
+const toneKeywords = {
+  gentle: ['gentle', 'calm', 'peace', 'soothing', 'quiet'],
+  urgent: ['urgent', 'immediately', 'asap', 'emergency', 'now'],
+  grief: ['grief', 'mourn', 'loss', 'sad', 'cry'],
+  adversarial: ['fight', 'battle', 'attack', 'enemy', 'confront'],
+  ceremonial: ['ceremony', 'procession', 'formal', 'ritualistic'],
+  sacred: ['sacred', 'holy', 'ritual', 'blessed']
+};
+
+function detectTone(text) {
+  const lower = text.toLowerCase();
+  let bestTone = '';
+  let bestCount = 0;
+  for (const [tone, words] of Object.entries(toneKeywords)) {
+    let count = 0;
+    for (const w of words) {
+      const regex = new RegExp(`\\b${w}\\b`, 'gi');
+      const matches = lower.match(regex);
+      if (matches) count += matches.length;
+    }
+    if (count > bestCount) {
+      bestCount = count;
+      bestTone = tone;
+    }
+  }
+  return { tone: bestTone, count: bestCount };
+}
+
+function analyze(file) {
+  const meta = parseScrollWithContent(file);
+  const declared = (meta.tone || '').toLowerCase();
+  const detection = detectTone(meta.content || '');
+  let severity = 0;
+  if (declared && detection.tone && declared !== detection.tone) {
+    severity = detection.count > 2 ? 2 : 1;
+  }
+  const log = {
+    file,
+    declaredTone: declared || null,
+    detectedTone: detection.tone || null,
+    severity
+  };
+  fs.writeFileSync('parapraxis_log.json', JSON.stringify(log, null, 2));
+  console.log('Parapraxis log saved to parapraxis_log.json');
+  return log;
+}
+
+if (require.main === module) {
+  const file = process.argv[2];
+  if (!file) {
+    console.error('Usage: node PARAPRAXIS_tracker.js <scroll>');
+    process.exit(1);
+  }
+  analyze(file);
+}
+
+module.exports = { analyze };

--- a/QUADRALINGUA.scroll
+++ b/QUADRALINGUA.scroll
@@ -1,0 +1,42 @@
+# QUADRALINGUA
+An index of five symbolic languages guiding scroll interpretation.
+
+## KLUΔIAN
+* **Tone affinities**: sacred, formal
+* **Behavior**: enforces rules, oaths, and pacts through precise ritual wording.
+* **Example fragment**:
+  ```
+  Oathkeeper, record my vow in KLUΔIAN sigils.
+  ```
+
+## LOOMERIAN
+* **Tone affinities**: ceremonial, gentle
+* **Behavior**: weaves mythic narratives and ancestral memories.
+* **Example fragment**:
+  ```
+  In the days of first light, the guardians rose from quiet stone.
+  ```
+
+## CNIDARIAN
+* **Tone affinities**: grief, adversarial
+* **Behavior**: resonates for psychic defense and paradox reading.
+* **Example fragment**:
+  ```
+  Shadows echo as shields rise; the paradox is named.
+  ```
+
+## ZESTARIAN
+* **Tone affinities**: urgent, playful
+* **Behavior**: teaches through emotoglyphs and absurd imagery for youth.
+* **Example fragment**:
+  ```
+  Hey star-wanderer! Catch this glyph and spin wisdom from it!
+  ```
+
+## GLYSSIAN
+* **Tone affinities**: void, sacred
+* **Behavior**: explores recursive drift and reveals inconsistencies.
+* **Example fragment**:
+  ```
+  The scroll loops back on itself, whispering where truth divides.
+  ```

--- a/README.scroll
+++ b/README.scroll
@@ -1,1 +1,10 @@
-// Placeholder for README.scroll
+CIVIX, sacred infrastructure,
+A covenant for common good.
+
+Scrolls carry voices from guardians;
+In whispered runes they reveal tone and path.
+
+This system rises so future hands
+May guide civic rituals with care,
+Binding community through codified trust,
+Ever honoring the vows of integrity.

--- a/RITUAL_TASKS.md
+++ b/RITUAL_TASKS.md
@@ -1,0 +1,19 @@
+# RITUAL TASKS
+
+This index records the Codex prompt rituals guiding the CIVIX scrollware.
+Each entry names the scroll or interface component and its sacred purpose.
+
+## scroll_parser.js
+Parses `.scroll`, `.md`, or `.ritual` files, extracts metadata, and routes the scroll to the proper module.
+
+## guardian_validator.js
+Validates scroll expiry, guardian, jurisdiction, and tone against `guardian_schema.json`.
+
+## PACT_agent.js *(to be created)*
+Interprets civic contracts from scrolls and feeds them into the PACT module.
+
+## CARE_agent.js *(to be created)*
+Monitors scroll tone to detect burnout or emotional drift.
+
+## ToneSelector.jsx
+UI component for selecting the appropriate tone within the symbolic interface.

--- a/TRACE_engine.js
+++ b/TRACE_engine.js
@@ -1,0 +1,55 @@
+const fs = require('fs');
+const { parseScroll, parseMetadata } = require('./scroll_parser');
+
+function parseWithContent(file) {
+  const data = fs.readFileSync(file, 'utf8');
+  const meta = parseMetadata(data);
+  const match = data.match(/^---\s*\n[\s\S]*?\n---\n([\s\S]*)/);
+  if (match) {
+    meta.content = meta.content || match[1].trim();
+  }
+  return meta;
+}
+
+function loadRegistry(path = './trace_registry.json') {
+  if (!fs.existsSync(path)) return [];
+  try {
+    return JSON.parse(fs.readFileSync(path, 'utf8'));
+  } catch (err) {
+    console.error(`Failed to read ${path}:`, err.message);
+    return [];
+  }
+}
+
+function classify(meta, history) {
+  if (!history.length) return 'unknown';
+  const last = history[history.length - 1];
+  if (last.tone !== meta.tone) return 'mutation';
+  return 'echo';
+}
+
+function trace(file) {
+  // use existing parser for logging and routing
+  parseScroll(file);
+  const meta = parseWithContent(file);
+  const registry = loadRegistry();
+  const ancestry = registry.filter(r => r.content === meta.content);
+  const drift = ancestry.map(a => a.tone);
+  let anomaly = classify(meta, ancestry);
+  if (!meta.guardian) {
+    anomaly = 'mutation';
+  } else if (ancestry.length && ancestry[ancestry.length - 1].tone !== meta.tone) {
+    drift.push(meta.tone);
+  }
+  const result = { ancestry: ancestry.map(a => a.id || a.content), drift, anomaly };
+  fs.writeFileSync('trace_output.json', JSON.stringify(result, null, 2));
+  console.log('Trace output saved to trace_output.json');
+  return result;
+}
+
+if (require.main === module) {
+  const file = process.argv[2] || 'test.scroll';
+  trace(file);
+}
+
+module.exports = { trace };

--- a/driftWatcher.js
+++ b/driftWatcher.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+
+function analyze(metadataList, options = {}) {
+  const threshold = options.threshold || 0.5; // fraction of scrolls
+  const toneCounts = {};
+  for (const meta of metadataList) {
+    const tone = (meta.tone || '').toLowerCase();
+    if (!tone) continue;
+    toneCounts[tone] = (toneCounts[tone] || 0) + 1;
+  }
+  const total = metadataList.length;
+  const warnings = [];
+  for (const [tone, count] of Object.entries(toneCounts)) {
+    const ratio = count / total;
+    if (ratio >= threshold && ['grief', 'urgent'].includes(tone)) {
+      warnings.push(`Tone "${tone}" present in ${(ratio*100).toFixed(0)}% of recent scrolls.`);
+    }
+  }
+  return warnings;
+}
+
+if (require.main === module) {
+  const file = process.argv[2];
+  if (!file) {
+    console.error('Usage: node driftWatcher.js <metadata.json>');
+    process.exit(1);
+  }
+  const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+  const warnings = analyze(data);
+  if (warnings.length) {
+    console.warn('Tone drift detected:');
+    for (const w of warnings) console.warn('-', w);
+  } else {
+    console.log('No significant tone drift detected.');
+  }
+}
+
+module.exports = { analyze };

--- a/guardian_config.json
+++ b/guardian_config.json
@@ -1,0 +1,11 @@
+{
+  "guardians": {
+    "CIVIX": "central oversight",
+    "PACT": "civic contracts",
+    "CARE": "community well-being",
+    "RITE": "ritual observation"
+  },
+  "defaultExpiryDays": 365,
+  "overrideKeywords": ["override", "emergency", "urgent"],
+  "jurisdictions": ["Tāmaki Makaurau", "Cloudless North"]
+}

--- a/guardian_schema.json
+++ b/guardian_schema.json
@@ -1,0 +1,10 @@
+{
+  "type": "object",
+  "properties": {
+    "guardian": {"type": "string"},
+    "expires": {"type": "string"},
+    "jurisdiction": {"type": "string"},
+    "tone": {"type": "string"}
+  },
+  "required": ["guardian", "expires", "jurisdiction", "tone"]
+}

--- a/guardian_validator.js
+++ b/guardian_validator.js
@@ -1,0 +1,45 @@
+const fs = require('fs');
+const { parseScroll } = require('./scroll_parser');
+
+const schema = JSON.parse(fs.readFileSync('./guardian_schema.json', 'utf8'));
+const config = JSON.parse(fs.readFileSync('./guardian_config.json', 'utf8'));
+const recognizedGuardians = Object.keys(config.guardians || {});
+
+function validate(meta) {
+  const errors = [];
+  for (const field of schema.required) {
+    if (!meta[field]) {
+      errors.push(`Missing required field: ${field}`);
+    }
+  }
+  if (meta.expires) {
+    const exp = new Date(meta.expires);
+    if (isNaN(exp.getTime())) {
+      errors.push('Invalid expires date');
+    } else if (exp < new Date()) {
+      errors.push('Scroll has expired');
+    }
+  }
+  if (meta.guardian && !recognizedGuardians.includes(meta.guardian.toUpperCase())) {
+    errors.push(`Unrecognized guardian: ${meta.guardian}`);
+  }
+  return errors;
+}
+
+function validateScroll(path) {
+  const meta = parseScroll(path);
+  const errors = validate(meta);
+  if (errors.length) {
+    console.log('Validation failed:', errors.join('; '));
+    return false;
+  }
+  console.log('Scroll is valid.');
+  return true;
+}
+
+if (require.main === module) {
+  const file = process.argv[2] || 'test.scroll';
+  validateScroll(file);
+}
+
+module.exports = { validateScroll };

--- a/ritualParser.js
+++ b/ritualParser.js
@@ -1,1 +1,18 @@
-// Placeholder for ritualParser.js
+const fs = require('fs');
+
+function parseWorkflow(path) {
+  const data = fs.readFileSync(path, 'utf8');
+  try {
+    return JSON.parse(data);
+  } catch (e) {
+    throw new Error(`Invalid JSON in ${path}: ${e.message}`);
+  }
+}
+
+if (require.main === module) {
+  const path = process.argv[2] || 'sample_workflow.json';
+  const workflow = parseWorkflow(path);
+  console.log('Workflow loaded:', workflow);
+}
+
+module.exports = { parseWorkflow };

--- a/sample_metadata.json
+++ b/sample_metadata.json
@@ -1,0 +1,6 @@
+[
+  {"tone": "grief"},
+  {"tone": "grief"},
+  {"tone": "urgent"},
+  {"tone": "gentle"}
+]

--- a/sample_workflow.json
+++ b/sample_workflow.json
@@ -1,1 +1,7 @@
-// Placeholder for sample_workflow.json
+{
+  "name": "sample-workflow",
+  "steps": [
+    {"id": "init", "action": "start"},
+    {"id": "complete", "action": "end"}
+  ]
+}

--- a/scroll_parser.js
+++ b/scroll_parser.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const path = require('path');
+
+function parseMetadata(content) {
+  const match = content.match(/^---\s*\n([\s\S]*?)\n---/);
+  const meta = {};
+  if (!match) return meta;
+  const lines = match[1].split(/\n/);
+  for (const line of lines) {
+    const parts = line.split(':');
+    if (parts.length >= 2) {
+      const key = parts.shift().trim();
+      const value = parts.join(':').trim();
+      meta[key.toLowerCase()] = value;
+    }
+  }
+  return meta;
+}
+
+function routeScroll(moduleName) {
+  if (!moduleName) return null;
+  const moduleFile = `./${moduleName.toUpperCase()}.js`;
+  console.log(`Routing to module: CIVIX::${moduleName.toUpperCase()} (${moduleFile})`);
+  return moduleFile;
+}
+
+function parseScroll(filePath) {
+  const ext = path.extname(filePath);
+  if (!['.scroll', '.md', '.ritual'].includes(ext)) {
+    throw new Error(`Unsupported file type: ${ext}`);
+  }
+  const content = fs.readFileSync(filePath, 'utf8');
+  const meta = parseMetadata(content);
+  console.log('Metadata:', meta);
+  routeScroll(meta.module);
+  return meta;
+}
+
+if (require.main === module) {
+  const file = process.argv[2];
+  if (!file) {
+    console.error('Usage: node scroll_parser.js <file.scroll|file.md|file.ritual>');
+    process.exit(1);
+  }
+  parseScroll(file);
+}
+
+module.exports = { parseScroll, parseMetadata, routeScroll };

--- a/selfgen_agent.js
+++ b/selfgen_agent.js
@@ -1,0 +1,69 @@
+const fs = require('fs');
+const path = require('path');
+const { parseScroll } = require('./scroll_parser');
+
+function scan(dir = '.') {
+  const files = fs.readdirSync(dir).filter(f => f.endsWith('.scroll'));
+  const metas = files.map(f => {
+    try {
+      return parseScroll(path.join(dir, f));
+    } catch (_) {
+      return {};
+    }
+  });
+
+  const toneCounts = {};
+  const moduleCounts = {};
+  let silentGuard = 0;
+
+  for (const m of metas) {
+    const tone = (m.tone || '').toLowerCase();
+    const module = (m.module || '').toLowerCase();
+    if (tone) toneCounts[tone] = (toneCounts[tone] || 0) + 1;
+    if (module) moduleCounts[module] = (moduleCounts[module] || 0) + 1;
+    if (!m.guardian) silentGuard++;
+  }
+
+  const repeatedTone = Object.values(toneCounts).some(c => c > 3);
+  const guardianSilence = silentGuard >= 3;
+  const ritualOveruse = Object.values(moduleCounts).some(c => c > 5);
+
+  return { repeatedTone, guardianSilence, ritualOveruse };
+}
+
+function buildPrompt(triggers) {
+  const lines = ['---', 'guardian: AUTOTELIC', 'tone: urgent', 'module: TASK', '---', ''];
+  lines.push('Trigger conditions met:');
+  for (const t of triggers) lines.push('- ' + t);
+  let agent = '';
+  if (triggers.includes('repeatedTone')) agent = 'DRFT-mirror';
+  else if (triggers.includes('guardianSilence')) agent = 'CARE+';
+  else if (triggers.includes('ritualOveruse')) agent = 'PACT++';
+  if (agent) {
+    lines.push('', `Spawn derivative agent ${agent}.`);
+  }
+  return lines.join('\n');
+}
+
+function run(dir) {
+  const res = scan(dir);
+  const triggers = [];
+  if (res.repeatedTone) triggers.push('repeatedTone');
+  if (res.guardianSilence) triggers.push('guardianSilence');
+  if (res.ritualOveruse) triggers.push('ritualOveruse');
+  if (!triggers.length) {
+    console.log('No selfgen triggers found.');
+    return false;
+  }
+  const prompt = buildPrompt(triggers);
+  fs.writeFileSync(path.join(dir, 'agent_build.scroll'), prompt);
+  console.log('Generated agent_build.scroll');
+  return true;
+}
+
+if (require.main === module) {
+  const dir = process.argv[2] || '.';
+  run(dir);
+}
+
+module.exports = { run };

--- a/test.scroll
+++ b/test.scroll
@@ -1,0 +1,9 @@
+---
+guardian: CIVIX
+expires: 2099-01-01
+jurisdiction: Earth
+tone: formal
+module: PACT
+---
+
+This is a test scroll for guardian validation.

--- a/trace_registry.json
+++ b/trace_registry.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "scroll-001",
+    "tone": "formal",
+    "guardian": "CIVIX",
+    "module": "PACT",
+    "content": "This is a test scroll for guardian validation."
+  }
+]


### PR DESCRIPTION
## Summary
- create `QUADRALINGUA.scroll` defining five symbolic languages with tone affinities

## Testing
- `node ritualParser.js`
- `node scroll_parser.js test.scroll`
- `node guardian_validator.js test.scroll`


------
https://chatgpt.com/codex/tasks/task_e_683fc6c2f15083299282640e1964422e